### PR TITLE
Create de_de.json

### DIFF
--- a/resources/assets/variant_crafting_tables/lang/de_de.json
+++ b/resources/assets/variant_crafting_tables/lang/de_de.json
@@ -1,0 +1,75 @@
+{
+"block.minecraft.crafting_table": "Eichen-Werkbank",
+"block.variant_crafting_tables.spruce_crafting_table": "Fichtenholz Werkbank",
+"block.variant_crafting_tables.birch_crafting_table": "Birkenholz Werkbank",
+"block.variant_crafting_tables.jungle_crafting_table": "Tropenholz Werkbank",
+"block.variant_crafting_tables.acacia_crafting_table": "Akazienholz Werkbank",
+"block.variant_crafting_tables.dark_oak_crafting_table": "Schwarzeichenholz Werkbank",
+"block.variant_crafting_tables.crimson_crafting_table": "Karmesin Werkbank",
+"block.variant_crafting_tables.warped_crafting_table": "Wirrholz Werkbank",
+
+"block.variant_crafting_tables.bop_cherry_crafting_table": "Kirschholz Werkbank",
+"block.variant_crafting_tables.bop_dead_crafting_table": "Totenholz Werkbank",
+"block.variant_crafting_tables.bop_fir_crafting_table": "Tannenholz Werkbank",
+"block.variant_crafting_tables.bop_hellbark_crafting_table": "Höllenborkenholz Werkbank",
+"block.variant_crafting_tables.bop_jacaranda_crafting_table": "Palisander Werkbank",
+"block.variant_crafting_tables.bop_magic_crafting_table": "Zauberholz Werkbank",
+"block.variant_crafting_tables.bop_mahogany_crafting_table": "Mahagonie Werkbank",
+"block.variant_crafting_tables.bop_palm_crafting_table": "Palmenholz Werkbank",
+"block.variant_crafting_tables.bop_redwood_crafting_table": "Rotholz Werkbank",
+"block.variant_crafting_tables.bop_umbran_crafting_table": "Schattenholz Werkbank",
+"block.variant_crafting_tables.bop_willow_crafting_table": "Weidenholz Werkbank",
+
+"block.variant_crafting_tables.canopy_crafting_table": "Baldachinholz Werkbank",
+"block.variant_crafting_tables.darkwood_crafting_table": "Dunkelholz Werkbank",
+"block.variant_crafting_tables.mangrove_crafting_table": "Mangrovenholz Werkbank",
+"block.variant_crafting_tables.minewood_crafting_table": "Minewood Werkbank",
+"block.variant_crafting_tables.sortingwood_crafting_table": "Sortierholz Werkbank",
+"block.variant_crafting_tables.timewood_crafting_table": "Zeitholz Werkbank",
+"block.variant_crafting_tables.transwood_crafting_table": "Wandelholz Werkbank",
+"block.variant_crafting_tables.twilight_oak_crafting_table": "Dämmerungseichenholz Werkbank",
+
+"block.variant_crafting_tables.aspen_crafting_table": "Espenholz Werkbank",
+"block.variant_crafting_tables.grimwood_crafting_table": "Grimmholz Werkbank",
+"block.variant_crafting_tables.kousa_crafting_table": "Kousa Werkbank",
+"block.variant_crafting_tables.morado_crafting_table": "Morado Werkbank",
+"block.variant_crafting_tables.rosewood_crafting_table": "Rosenholz Werkbank",
+"block.variant_crafting_tables.yucca_crafting_table": "Yucca Werkbank",
+
+"block.variant_crafting_tables.maple_crafting_table": "Ahornholz Werkbank",
+
+"block.variant_crafting_tables.bamboo_crafting_table": "Bambus Werkbank",
+
+"block.variant_crafting_tables.poise_crafting_table": "Poise Werkbank",
+
+"block.variant_crafting_tables.cherry_crafting_table": "Kirschholz Werkbank",
+"block.variant_crafting_tables.willow_crafting_table": "Weidenholz Werkbank",
+"block.variant_crafting_tables.wisteria_crafting_table": "Wisteriaholz Werkbank",
+
+"block.variant_crafting_tables.driftwood_crafting_table": "Treibholz Werkbank",
+"block.variant_crafting_tables.river_crafting_table": "Fluss Werkbank",
+
+"block.variant_crafting_tables.jacaranda_crafting_table": "Jacaranda Werkbank",
+"block.variant_crafting_tables.redbud_crafting_table": "Redbud Werkbank",
+
+"block.variant_crafting_tables.cypress_crafting_table": "Zypressenholz Werkbank",
+
+"block.variant_crafting_tables.brown_mushroom_crafting_table": "Braunpilz Werkbank",
+"block.variant_crafting_tables.red_mushroom_crafting_table": "Rotpilz Werkbank",
+"block.variant_crafting_tables.glowshroom_crafting_table": "Glühpilz Werkbank",
+
+"block.variant_crafting_tables.petrified_crafting_table": "Versteinerte Werkbank",
+
+"block.variant_crafting_tables.fairy_ring_mushroom_crafting_table": "Feenring Pilz Werkbank",
+
+"block.variant_crafting_tables.azure_crafting_table": "Azurblaue Werkbank",
+
+"item.variant_crafting_tables.oak_crafting_table_minecart": "Lore mit Eichenholz Werkbank",
+"item.variant_crafting_tables.spruce_crafting_table_minecart": "Lore mit Fichtenholz Werkbank",
+"item.variant_crafting_tables.birch_crafting_table_minecart": "Lore mit Birkenholz Werkbank",
+"item.variant_crafting_tables.jungle_crafting_table_minecart": "Lore mit Tropenholz Werkbank",
+"item.variant_crafting_tables.acacia_crafting_table_minecart": "Lore mit Akazienholz Werkbank",
+"item.variant_crafting_tables.dark_oak_crafting_table_minecart": "Lore mit Schwarzeichenholz Werkbank",
+"item.variant_crafting_tables.crimson_crafting_table_minecart": "Lore mit Karmesin Werkbank",
+"item.variant_crafting_tables.warped_crafting_table_minecart": "Lore mit Wirrholz Werkbank"
+}


### PR DESCRIPTION
initial german translation, matches en_us now.  But there are more types of wood, besides of BoP and TF, than you stated in the mod description. Had to guess what is meant. Maybe you can update the description which mods are additionally supported? Br