### PR TITLE
Hex Casting: migrated plank ID from akashic_planks to edified_planks

### DIFF
--- a/src/main/resources/data/vct/recipes/akashic_crafting_table.json
+++ b/src/main/resources/data/vct/recipes/akashic_crafting_table.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "hexcasting:akashic_planks"
+      "item": "hexcasting:edified_planks"
     }
   },
   "result": {


### PR DESCRIPTION
This fixes compatibility with the latest version of Hex Casting.